### PR TITLE
Added Linux Mint support to scripts + GH Workflow

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Install package
       run: |
           sudo dpkg -i ./build/wireguird_amd64.deb
+          sudo apt-get -f install
 
 
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -21,11 +21,11 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Install Package Dependencies
-      run: |
-          echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
-          sudo apt-get update
-          sudo apt-get install -y wireguard-tools libgtk-3-dev libayatana-appindicator3-dev golang-go resolvconf
+#    - name: Install Package Dependencies
+#      run: |
+#          echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
+#          sudo apt-get update
+#          sudo apt-get install -y wireguard-tools libgtk-3-dev libayatana-appindicator3-dev golang-go resolvconf
 
     - name: Build .deb
       run: |

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,29 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Build wireguird .deb
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Install Dependencies
+      run: deps.sh
+
+    - name: Build
+      run: package_deb.sh
+

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -34,8 +34,8 @@ jobs:
     
     - name: Install package
       run: |
-          sudo dpkg -i ./build/wireguird_amd64.deb
-          sudo apt-get -f install
+          sudo apt install ./build/wireguird_amd64.deb
+
 
 
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -21,9 +21,6 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Install Dependencies
-      run: deps.sh
-
     - name: Build
       run: package_deb.sh
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -21,6 +21,16 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Build
-      run: package_deb.sh
+    - name: Install Package Dependencies
+      run: |
+          echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
+          sudo apt-get update
+          sudo apt-get install -y wireguard-tools libgtk-3-dev libayatana-appindicator3-dev golang-go resolvconf
+
+    - name: Build .deb
+      run: |
+          chmod +x *.sh
+          ./package_deb.sh
+
+
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -34,7 +34,7 @@ jobs:
     
     - name: Install package
       run: |
-          dpkg -i ./build/wireguird_amd64.deb
+          sudo dpkg -i ./build/wireguird_amd64.deb
 
 
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -31,6 +31,10 @@ jobs:
       run: |
           chmod +x *.sh
           ./package_deb.sh
+    
+    - name: Install package
+      run: |
+          dpkg -i ./build/wireguird_amd64.deb
 
 
 

--- a/deps.sh
+++ b/deps.sh
@@ -7,5 +7,8 @@ if [[ -f "/etc/os-release" ]]; then
         sudo apt install wireguard-tools libgtk-3-dev libayatana-appindicator3-dev golang-go resolvconf
     elif [[ "${ID}" == "debian" ]]; then
         sudo apt install wireguard-tools libgtk-3-dev libayatana-appindicator3-dev golang-go resolvconf
+    elif [[ "${ID}" == "linuxmint" ]]; then
+        sudo apt install wireguard-tools libgtk-3-dev libayatana-appindicator3-dev golang-go resolvconf
+    
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,8 @@ if [[ -f "/etc/os-release" ]]; then
         #sudo rpm
     elif [[ "${ID}" == "ubuntu" ]]; then
         sudo dpkg -i ./build/wireguird_amd64.deb
+    elif [[ "${ID}" == "linuxmint" ]]; then
+        sudo dpkg -i ./build/wireguird_amd64.deb
     fi
 fi
 

--- a/package.sh
+++ b/package.sh
@@ -7,5 +7,8 @@ if [[ -f "/etc/os-release" ]]; then
     elif [[ "${ID}" == "ubuntu" ]]; then
         echo "deb package"
         ./package_deb.sh
+    elif [[ "${ID}" == "linuxmint" ]]; then
+        echo "deb package"
+        ./package_deb.sh
     fi
 fi


### PR DESCRIPTION
I added the 'linuxmint' /etc/os-release ID attribute to the scripts so that the installation/building scripts work on Linux Mint too.
Tested on Mint 21.2